### PR TITLE
色々更新

### DIFF
--- a/UnityProjectPostProcessor/UnityProjectPostProcessor/CSharpProject.cs
+++ b/UnityProjectPostProcessor/UnityProjectPostProcessor/CSharpProject.cs
@@ -99,11 +99,29 @@ namespace UnityProjectPostProcessor
         private static readonly Regex regAnalyzer = new Regex(@"\s*\<Analyzer Include=""(?<path>.*?)"" /\>", RegexOptions.Compiled);
         private static readonly Regex regProjectClose = new Regex(@"\</Project\>", RegexOptions.Compiled);
         private static readonly Regex regLangVersion = new Regex(@"\<LangVersion.*?\</LangVersion\>", RegexOptions.Compiled);
+        private static readonly Regex regTargetFrameworkProfile = new Regex(@"\<TargetFrameworkProfile.*?\</TargetFrameworkProfile\>", RegexOptions.Compiled);
         private static readonly IEnumerable<Regex> regReferenceList = new[]
         {
             regReference,
             regReferenceHintPath,
         };
+
+        /// <summary>
+        /// <![CDATA[
+        /// <TargetFrameworkProfile>Unity Subset v3.5</TargetFrameworkProfile>
+        /// ]]>
+        /// タグがあると、新形式 csproj (<![CDATA[ <Project Sdk="Microsoft.NET.Sdk"> ]]>が入ってるやつ)との混在でうまくビルドが出来なくなるので、消す。
+        /// </summary>
+        /// <remarks>
+        /// 副作用として、「.NET 3.5には含まれてるけどもUnityでは使えないはずのクラスを触れてしまう」という問題がなくはない。
+        /// とはいえ、それはVisual Studio内だけの問題で、Unity上でのビルドでわかるし、
+        /// その条件に当てはまるクラス自体が少ないはずなので、
+        /// 大した問題ではないはず。
+        /// </remarks>
+        public void RemoveTargetFrameworkProfile()
+        {
+            Content = regTargetFrameworkProfile.Replace(Content, "");
+        }
 
         /// <summary>
         /// バージョン指定。

--- a/UnityProjectPostProcessor/UnityProjectPostProcessor/Project.cs
+++ b/UnityProjectPostProcessor/UnityProjectPostProcessor/Project.cs
@@ -37,7 +37,16 @@ namespace UnityProjectPostProcessor
         {
             Path = System.IO.Path.GetFullPath(path);
             Content = content;
-            Guid = GetProjectGuid(Content);
+
+            try
+            {
+                // GUID が入ってないことがあるので、その場合は例外を無視。
+                Guid = GetProjectGuid(Content);
+            }
+            catch
+            {
+                Guid = Guid.NewGuid();
+            }
         }
 
         /// <summary>
@@ -63,8 +72,7 @@ namespace UnityProjectPostProcessor
         /// <returns>プロジェクト。</returns>
         internal static T GetProject<T>(string path, Func<string, T> creator) where T : Project
         {
-            Project project;
-            if (!_projectChace.TryGetValue(path, out project))
+            if (!_projectChace.TryGetValue(path, out var project))
             {
                 project = creator(path);
                 _projectChace.Add(path, project);


### PR DESCRIPTION
- CopyDllsAfterBuild を使ったDLLコピー用ダミープロジェクトを起点にコード生成するのが前提になってきたので、起点プロジェクトはUnity側に持ってこないようにした
  - GameProject → RootProject にリネーム
- 新 csproj 形式内にはGUIが入ってないせいで例外が出てた問題に対処
  - GUID でプロジェクトの等価判定できなくなったので、フルパスで判定するように
- Editor プロジェクト側でも `<LangVersion>4</LangVersion>` を消すようにした
- `TargetFrameworkProfile` が問題を起こしてたので消すことにした