### PR TITLE
[copy dll] 拡張子以外完全一致ファイルのみ除外できるように

### DIFF
--- a/CopyDllsAfterBuild/CopyDllsAfterBuild.nuspec
+++ b/CopyDllsAfterBuild/CopyDllsAfterBuild.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>CopyDllsAfterBuild</id>
-    <version>3.1.2</version>
+    <version>3.1.3</version>
     <title>Copy Dlls after build</title>
     <authors>Nobuyuki Iwanaga</authors>
     <owners>Nobuyuki Iwanaga</owners>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/ufcpp/UnityTools/blob/master/CopyDllsAfterBuild</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Copy DLLs to a external folder and generate .mdb files on post build.</description>
-    <releaseNotes>Fixed bug.</releaseNotes>
+    <releaseNotes>Add excludes '$' character option.</releaseNotes>
     <copyright>Nobuyuki Iwanaga</copyright>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />

--- a/CopyDllsAfterBuild/tools/copy_dlls.ps1
+++ b/CopyDllsAfterBuild/tools/copy_dlls.ps1
@@ -11,7 +11,21 @@ foreach ($ext in 'dll', 'pdb', 'xml', 'dll.mdb')
 {
     $destinationFiles = [IO.Path]::Combine($destination, '*.' + $ext)
     $sourceFiles = [IO.Path]::Combine($source, $pattern + '.' + $ext)
-    [string[]] $excludeFiles = $excludes | %{ $_ + '.*'}
+
+    $excludeFiles = $excludes
+    $len = $excludes.Length
+    for ($i = 0; $i -lt $len; $i++)
+    {
+        # When end with '$' character, excludes above extention specified files and full match ones only.
+        if ($excludes[$i].EndWith("$"))
+        {
+            $excludeFiles[$i] = $excludes[$i].Substring(0, $excludes[$i].Length - 1) + '.' + $ext
+        }
+        else
+        {
+            $excludeFiles[$i] = $excludes[$i] + ".*"
+        }
+    }
 
     if (Test-Path $destinationFiles) { rm $destinationFiles }
 

--- a/CopyDllsAfterBuild/tools/copy_dlls.ps1
+++ b/CopyDllsAfterBuild/tools/copy_dlls.ps1
@@ -16,7 +16,7 @@ foreach ($ext in 'dll', 'pdb', 'xml', 'dll.mdb')
     $len = $excludes.Length
     for ($i = 0; $i -lt $len; $i++)
     {
-        # When end with '$' character, excludes above extention specified files and full match ones only.
+        # `$` means end of a file name excluding the extension.
         if ($excludes[$i].EndWith("$"))
         {
             $excludeFiles[$i] = $excludes[$i].Substring(0, $excludes[$i].Length - 1) + '.' + $ext


### PR DESCRIPTION
CopySettings.json の excludes に指定する除外ファイルキーワードの末尾に
$ を指定することで拡張子以外が完全一致するファイルのみを除外対象にできるようにする