### PR TITLE
フォルダー除外

### DIFF
--- a/CopyDllsAfterBuild/CopyDllsAfterBuild.nuspec
+++ b/CopyDllsAfterBuild/CopyDllsAfterBuild.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>CopyDllsAfterBuild</id>
-    <version>4.0.0</version>
+    <version>4.1.0</version>
     <title>Copy Dlls after build</title>
     <authors>Nobuyuki Iwanaga</authors>
     <owners>Nobuyuki Iwanaga</owners>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/ufcpp/UnityTools/blob/master/CopyDllsAfterBuild</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Copy DLLs/PDBs to a external folder on post build.</description>
-    <releaseNotes>Removed pdb2mdb support.</releaseNotes>
+    <releaseNotes>Add support for exclude_folders</releaseNotes>
     <copyright>Nobuyuki Iwanaga</copyright>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />

--- a/CopyDllsAfterBuild/tools/copy_dlls.ps1
+++ b/CopyDllsAfterBuild/tools/copy_dlls.ps1
@@ -12,8 +12,8 @@ foreach ($ext in 'dll', 'pdb', 'xml')
     $destinationFiles = [IO.Path]::Combine($destination, '*.' + $ext)
     $sourceFiles = [IO.Path]::Combine($source, $pattern + '.' + $ext)
 
-    $excludeFiles = $excludes
     $len = $excludes.Length
+    $excludeFiles = [string[]]::new($len)
     for ($i = 0; $i -lt $len; $i++)
     {
         # `$` means end of a file name excluding the extension.
@@ -27,7 +27,7 @@ foreach ($ext in 'dll', 'pdb', 'xml')
         }
     }
 
-    if (Test-Path $destinationFiles) { rm $destinationFiles }
+    if (Test-Path $destinationFiles) { Remove-Item $destinationFiles }
 
     Copy-Item $sourceFiles $destination -Exclude $excludeFiles
 }

--- a/CopyDllsAfterBuild/tools/postbuild.ps1
+++ b/CopyDllsAfterBuild/tools/postbuild.ps1
@@ -12,6 +12,19 @@ $dllPath = [IO.Path]::Combine($ProjectDir, $settings.destination)
 
 $pattern = $settings.pattern
 if ($null -eq $pattern) { $pattern = '*' }
-if ($pattern -eq $null) { $pattern = '*' }
+
+$excludesFromFolder = @()
+
+foreach ($excludeFolder in $settings.exclude_folders) {
+    foreach ($excludeFile in Get-ChildItem ($ProjectDir + $excludeFolder)) {
+        if (-not ([string]$excludeFile).EndsWith(('meta'))) {
+            $excludesFromFolder += [IO.Path]::GetFileNameWithoutExtension($excludeFile.Name)
+        }
+    }
+}
+
+foreach ($excludeFile in ($excludesFromFolder | Get-Unique)) {
+    $excludes += $excludeFile
+}
 
 . ./copy_dlls.ps1 $TargetDir $dllPath $pattern $excludes

--- a/CopyDllsAfterBuild/tools/postbuild.ps1
+++ b/CopyDllsAfterBuild/tools/postbuild.ps1
@@ -11,6 +11,7 @@ $dllPath = [IO.Path]::Combine($ProjectDir, $settings.destination)
 [string[]] $excludes = $settings.excludes
 
 $pattern = $settings.pattern
+if ($null -eq $pattern) { $pattern = '*' }
 if ($pattern -eq $null) { $pattern = '*' }
 
 . ./copy_dlls.ps1 $TargetDir $dllPath $pattern $excludes


### PR DESCRIPTION
フォルダー内のファイルと同名のものを全除外する機能を追加。
CopySettings.json に `"exclude_folders": [ "path to folder" ]` を足せば有効に。