### PR TITLE
[fix] exclude_folders で除外する際、前方一致になってた

### DIFF
--- a/CopyDllsAfterBuild/CopyDllsAfterBuild.nuspec
+++ b/CopyDllsAfterBuild/CopyDllsAfterBuild.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>CopyDllsAfterBuild</id>
-    <version>4.1.0</version>
+    <version>4.2.0</version>
     <title>Copy Dlls after build</title>
     <authors>Nobuyuki Iwanaga</authors>
     <owners>Nobuyuki Iwanaga</owners>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/ufcpp/UnityTools/blob/master/CopyDllsAfterBuild</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Copy DLLs/PDBs to a external folder on post build.</description>
-    <releaseNotes>Add support for exclude_folders</releaseNotes>
+    <releaseNotes>small fix</releaseNotes>
     <copyright>Nobuyuki Iwanaga</copyright>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />

--- a/CopyDllsAfterBuild/tools/postbuild.ps1
+++ b/CopyDllsAfterBuild/tools/postbuild.ps1
@@ -18,7 +18,7 @@ $excludesFromFolder = @()
 foreach ($excludeFolder in $settings.exclude_folders) {
     foreach ($excludeFile in Get-ChildItem ($ProjectDir + $excludeFolder)) {
         if (-not ([string]$excludeFile).EndsWith(('meta'))) {
-            $excludesFromFolder += [IO.Path]::GetFileNameWithoutExtension($excludeFile.Name)
+            $excludesFromFolder += [IO.Path]::GetFileNameWithoutExtension($excludeFile.Name) + '$' # exact match instead of prefix match
         }
     }
 }


### PR DESCRIPTION
指定フォルダーに A.dll がいるとき、 A1.dll とかも巻き添えで除外扱いされてた。