### PR TITLE
feat: add .meta as destinationIgnore extensions

### DIFF
--- a/CopyDllsAfterBuildLocalTool/CopyDllsAfterBuildLocalTool/CopyDllsAfterBuildLocalTool.csproj
+++ b/CopyDllsAfterBuildLocalTool/CopyDllsAfterBuildLocalTool/CopyDllsAfterBuildLocalTool.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <RollForward>LatestMajor</RollForward>
     <Nullable>enable</Nullable>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
   </PropertyGroup>
 

--- a/CopyDllsAfterBuildLocalTool/CopyDllsAfterBuildLocalTool/Copyer.cs
+++ b/CopyDllsAfterBuildLocalTool/CopyDllsAfterBuildLocalTool/Copyer.cs
@@ -12,6 +12,7 @@ namespace CopyDllsAfterBuildLocalTool
         private const string ExactMatchMarker = "$";
 
         private static readonly string[] unityPluginExtensions = new[] { "dll", "pdb", "xml" };
+        private static readonly string[] destinationIgnoreExtensions = new[] { ".meta" };
         private static readonly ILogger logger = Logger.Instance;
         // destination depth will be only top directory. ignore for child folder in destination path.
         private static readonly SearchOption searchOption = SearchOption.TopDirectoryOnly;
@@ -122,7 +123,10 @@ namespace CopyDllsAfterBuildLocalTool
 
             // delete all except copy target.
             var destinationFiles = Directory.EnumerateFiles(destination, $"*", searchOption);
-            var deleteFiles = destinationFiles.Except(sourceFiles.Select(x => Path.Combine(destination, Path.GetFileName(x)))).ToArray();
+            var deleteFiles = destinationFiles
+                .Where(x => !destinationIgnoreExtensions.Contains(Path.GetExtension(x)))
+                .Except(sourceFiles.Select(x => Path.Combine(destination, Path.GetFileName(x))))
+                .ToArray();
             Delete(deleteFiles);
 
             // copy!

--- a/CopyDllsAfterBuildLocalTool/CopyDllsAfterBuildLocalTool/Copyer.cs
+++ b/CopyDllsAfterBuildLocalTool/CopyDllsAfterBuildLocalTool/Copyer.cs
@@ -11,7 +11,7 @@ namespace CopyDllsAfterBuildLocalTool
         // `$` means end of a file name exclude the extension. if file name is end with this marker, will do exact match.
         private const string ExactMatchMarker = "$";
 
-        private static readonly string[] unityPluginExtensions = new[] { "dll", "pdb", "xml" };
+        private static readonly string[] unityPluginExtensions = new[] { ".dll", ".pdb", ".xml" };
         private static readonly string[] destinationIgnoreExtensions = new[] { ".meta" };
         private static readonly ILogger logger = Logger.Instance;
         // destination depth will be only top directory. ignore for child folder in destination path.
@@ -108,7 +108,7 @@ namespace CopyDllsAfterBuildLocalTool
             foreach (var ext in unityPluginExtensions)
             {
                 // source candidates
-                var candicates = Directory.EnumerateFiles(source, $"{pattern}.{ext}", searchOption);
+                var candicates = Directory.EnumerateFiles(source, $"{pattern}{ext}", searchOption);
                 if (!candicates.Any())
                 {
                     // origin not found, go next.
@@ -156,7 +156,7 @@ namespace CopyDllsAfterBuildLocalTool
                 if (excludes[i].EndsWith(ExactMatchMarker))
                 {
                     // exact match. remove $ marker.
-                    exactMatchExcludeFiles[exactIndex] = excludes[i].Substring(0, excludes[i].Length - 1) + "." + extention;
+                    exactMatchExcludeFiles[exactIndex] = excludes[i].Substring(0, excludes[i].Length - 1) + extention;
                     exactIndex++;
                 }
                 else

--- a/CopyDllsAfterBuildLocalTool/CopyDllsAfterBuildLocalToolUnitTest/CommandTest.cs
+++ b/CopyDllsAfterBuildLocalTool/CopyDllsAfterBuildLocalToolUnitTest/CommandTest.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace CopyDllsAfterBuildLocalToolUnitTest
 {
-    public class E2E_CommandTest : IDisposable
+    public class CommandTest : IDisposable
     {
         private readonly string _basePath;
         private readonly string _projectDir;
@@ -16,7 +16,7 @@ namespace CopyDllsAfterBuildLocalToolUnitTest
         private readonly string _settings;
 
         // setup
-        public E2E_CommandTest()
+        public CommandTest()
         {
             var random = Guid.NewGuid().ToString();
             _basePath = Path.Combine(Path.GetTempPath(), "CommandTest", random);
@@ -146,7 +146,8 @@ namespace CopyDllsAfterBuildLocalToolUnitTest
 
             // 3rd run. add garbage file to destination
             {
-                File.WriteAllText(Path.Combine(destinationPath, "a"), "abcde");
+                var garbageFile = Path.Combine(destinationPath, "a");
+                File.WriteAllText(garbageFile, "abcde");
                 var before3rd = getActual(destinationPath);
                 program.Run(_projectDir, _targetDir);
                 var actual3rd = getActual(destinationPath);
@@ -158,6 +159,8 @@ namespace CopyDllsAfterBuildLocalToolUnitTest
                     // date not updated
                     Assert.Equal(expected2[actualItem.Key].date, actualItem.Value.date);
                 }
+                // garbage file must be deleted.
+                Assert.False(File.Exists(garbageFile));
             }
 
             // 4th run. change source dll.

--- a/CopyDllsAfterBuildLocalTool/README.md
+++ b/CopyDllsAfterBuildLocalTool/README.md
@@ -22,6 +22,7 @@ dotnet tool install CopyDllsAfterBuildLocalTool --version 0.1.0
 
 ```csproj
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="dotnet tool restore" /> 
     <Exec Command="dotnet tool run dotnet-copydllsafterbuild run &#45;&#45;project-dir $(ProjectDir) &#45;&#45;target-dir $(TargetDir)" />
   </Target>
 ```
@@ -32,6 +33,20 @@ dotnet tool install CopyDllsAfterBuildLocalTool --version 0.1.0
 
 ```shell
 dotnet tool run dotnet-copydllsafterbuild init
+```
+
+This will output CopySettings.json template.
+
+```json
+{
+  "destination": "../../project/Assets/Dlls",
+  "pattern": "*",
+  "excludes": [
+    "UnityEngine",
+    "UnityEditor"
+  ],
+  "exclude_folders": []
+}
 ```
 
 * Step4. (Optional) Modify CopySettings.json if needed. You can check json is valid via `validate` command.
@@ -58,6 +73,15 @@ COPYDLLS_LOGLEVEL=Debug && dotnet build
 ```
 
 > Windows users, use `set COPYDLLS_LOGLEVEL=Debug`.
+
+### Is Unity .meta file also deleted via tool?
+
+No, `*.meta` files exsisting on destination path will not be deleted via tool.
+
+### Is .gitignore file or other . files deleted via tool?
+
+Yes, all file names except `*.meta` will be deleted.
+Please move `.gitignore` file to outside destination.
 
 ### Can I run tool as ConsoleApp?
 


### PR DESCRIPTION
## TL;DR;

* .meta is Unity's meta file and should not automatically deleted via CopyDllsAfterBuildLocalTool.
* small changes to test.